### PR TITLE
Add MySQL login verification helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,53 @@ Now in Ultimate Team Web App, new menu will be added as AutoBuyer.
 
 - If enabled tool will gives sound notification for actions like buy card / captcha trigger etc...
 
+## MySQL Login Verification Service
+
+The project now ships with a small authentication helper located at
+`app/services/auth/mysqlAuthService.js`. The helper creates a login verifier
+that talks directly to a MySQL database using the [`mysql2`](https://www.npmjs.com/package/mysql2)
+driver. To use it, install the dependency in your Node.js environment and create
+the service with your database configuration:
+
+```bash
+npm install mysql2
+# or
+yarn add mysql2
+```
+
+```js
+import bcrypt from "bcrypt";
+import { createMySQLAuthService } from "./app/services/auth";
+
+const authService = createMySQLAuthService(
+  {
+    host: "db-host",
+    user: "db-user",
+    password: "secret",
+    database: "magicbuyer",
+  },
+  {
+    tableName: "users",
+    usernameField: "email",
+    selectFields: ["id", "email", "role"],
+    // Example: integrate bcrypt comparison logic if your passwords are hashed.
+    passwordComparator: async (inputPassword, storedHash) =>
+      bcrypt.compare(inputPassword, storedHash),
+  }
+);
+
+const result = await authService.login("user@example.com", "sup3rs3cret");
+if (result.success) {
+  console.log("Logged in!", result.user);
+} else {
+  console.error("Login failed", result.reason, result.error);
+}
+```
+
+When the credentials are valid, the returned object contains the non-sensitive
+fields requested via `selectFields`. On failure, a descriptive `reason` is
+provided (`USER_NOT_FOUND`, `INVALID_PASSWORD`, or `ERROR`).
+
 ## Prerequisites
 
 - To use this tool, the user should have access to the transfer market.

--- a/app/services/auth/index.js
+++ b/app/services/auth/index.js
@@ -1,0 +1,4 @@
+import { createMySQLAuthService } from "./mysqlAuthService";
+
+export { createMySQLAuthService };
+

--- a/app/services/auth/mysqlAuthService.js
+++ b/app/services/auth/mysqlAuthService.js
@@ -1,0 +1,206 @@
+/**
+ * Factory function that creates a login verifier backed by a MySQL database.
+ *
+ * The resulting service exposes a single `login` method that resolves to an
+ * object describing the authentication result. It lazily loads the
+ * `mysql2/promise` module so the dependency is only required in Node
+ * environments where it is available. This design keeps the rest of the
+ * application usable in browser-only builds.
+ *
+ * @param {import("mysql2").ConnectionOptions|Record<string, any>} connectionConfig
+ *   Configuration object that is passed to `mysql2/promise#createConnection` when
+ *   a connection needs to be created. This object is ignored when a
+ *   `connectionProvider` is supplied.
+ * @param {Object} [options]
+ * @param {string} [options.tableName="users"]
+ *   Table that contains the credential information.
+ * @param {string} [options.usernameField="username"]
+ *   Column that stores the username / email / identifier.
+ * @param {string} [options.passwordField="password"]
+ *   Column that stores the password hash/value.
+ * @param {string[]} [options.selectFields]
+ *   Additional columns to include in the query result. If omitted, the service
+ *   selects the record `id` and the configured `usernameField`.
+ * @param {(providedPassword: string, storedPassword: any, userRecord: any) =>
+ *   boolean|Promise<boolean>} [options.passwordComparator]
+ *   Custom comparison function that can handle hashing strategies such as
+ *   bcrypt or argon. Must resolve to a boolean value.
+ * @param {() => any|Promise<any>} [options.connectionProvider]
+ *   Optional callback that can provide a pre-configured connection or pool.
+ *   The callback may return either the raw connection/pool instance or an
+ *   object of shape `{ connection, shouldClose, release }` to control cleanup.
+ */
+export const createMySQLAuthService = (
+  connectionConfig,
+  {
+    tableName = "users",
+    usernameField = "username",
+    passwordField = "password",
+    selectFields,
+    passwordComparator,
+    connectionProvider,
+  } = {}
+) => {
+  if (!connectionConfig || typeof connectionConfig !== "object") {
+    throw new Error(
+      "A MySQL connection configuration object must be provided to createMySQLAuthService."
+    );
+  }
+
+  let normalizedSelectFields = selectFields;
+  if (!normalizedSelectFields) {
+    normalizedSelectFields = ["id", usernameField];
+  }
+
+  if (!Array.isArray(normalizedSelectFields)) {
+    throw new Error("selectFields must be an array when provided.");
+  }
+
+  const defaultComparator = (providedPassword, storedPassword) => {
+    let comparableStored = storedPassword;
+    if (
+      comparableStored !== null &&
+      comparableStored !== undefined &&
+      typeof comparableStored === "object" &&
+      typeof comparableStored.toString === "function"
+    ) {
+      comparableStored = comparableStored.toString();
+    } else {
+      comparableStored = String(comparableStored ?? "");
+    }
+
+    return Promise.resolve(providedPassword === comparableStored);
+  };
+
+  const comparator = passwordComparator
+    ? (providedPassword, storedPassword, userRecord) =>
+        Promise.resolve(
+          passwordComparator(providedPassword, storedPassword, userRecord)
+        )
+    : defaultComparator;
+
+  let mysqlModulePromise;
+
+  const getMysqlModule = () => {
+    mysqlModulePromise = mysqlModulePromise || import("mysql2/promise");
+    return mysqlModulePromise;
+  };
+
+  const getConnection = async () => {
+    if (typeof connectionProvider === "function") {
+      const providedConnection = await connectionProvider();
+      if (!providedConnection) {
+        throw new Error(
+          "The connectionProvider did not return a valid MySQL connection."
+        );
+      }
+      if (
+        typeof providedConnection === "object" &&
+        "connection" in providedConnection
+      ) {
+        return {
+          connection: providedConnection.connection,
+          shouldClose: Boolean(providedConnection.shouldClose),
+          release: providedConnection.release,
+        };
+      }
+
+      return { connection: providedConnection, shouldClose: false };
+    }
+
+    const mysql = await getMysqlModule();
+    const createdConnection = await mysql.createConnection(connectionConfig);
+    return { connection: createdConnection, shouldClose: true };
+  };
+
+  const sanitizeUser = (userRecord, fieldsToKeep) => {
+    const result = {};
+    fieldsToKeep.forEach((field) => {
+      if (field !== passwordField && field in userRecord) {
+        result[field] = userRecord[field];
+      }
+    });
+    return result;
+  };
+
+  const login = async (username, password) => {
+    const normalizedUsername = String(username).trim();
+    const normalizedPassword = String(password);
+
+    if (!normalizedUsername || !normalizedPassword) {
+      throw new Error("Both username and password are required for login.");
+    }
+
+    let connection;
+    let shouldCloseConnection = false;
+    let releaseConnection;
+    try {
+      const connectionDetails = await getConnection();
+      connection = connectionDetails.connection;
+      shouldCloseConnection = connectionDetails.shouldClose;
+      releaseConnection = connectionDetails.release;
+
+      const fieldsToSelect = Array.from(
+        new Set([...(normalizedSelectFields || []), usernameField, passwordField])
+      );
+
+      const [rows] = await connection.execute(
+        `SELECT ${fieldsToSelect
+          .map((field) => `\`${field}\``)
+          .join(", ")} FROM \`${tableName}\` WHERE \`${usernameField}\` = ? LIMIT 1`,
+        [normalizedUsername]
+      );
+
+      if (!rows.length) {
+        return { success: false, reason: "USER_NOT_FOUND" };
+      }
+
+      const userRecord = rows[0];
+      const isPasswordValid = await comparator(
+        normalizedPassword,
+        userRecord[passwordField],
+        userRecord
+      );
+
+      if (typeof isPasswordValid !== "boolean") {
+        throw new Error(
+          "The passwordComparator must resolve to a boolean value."
+        );
+      }
+
+      if (!isPasswordValid) {
+        return { success: false, reason: "INVALID_PASSWORD" };
+      }
+
+      return {
+        success: true,
+        user: sanitizeUser(userRecord, fieldsToSelect),
+      };
+    } catch (error) {
+      return {
+        success: false,
+        reason: "ERROR",
+        error: error instanceof Error ? error.message : String(error),
+      };
+    } finally {
+      if (connection && shouldCloseConnection && typeof connection.end === "function") {
+        try {
+          await connection.end();
+        } catch (closeError) {
+          // Ignore connection closing errors to avoid masking the original error.
+        }
+      }
+
+      if (typeof releaseConnection === "function") {
+        try {
+          await releaseConnection();
+        } catch (releaseError) {
+          // Ignore release errors as they are non-critical cleanup issues.
+        }
+      }
+    }
+  };
+
+  return { login };
+};
+

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "author": "AMINE1921",
   "license": "ISC",
   "dependencies": {
+    "mysql2": "^3.11.0",
     "webpack": "^5.47.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- add a configurable MySQL-backed login verification service that lazily loads the mysql2 driver
- expose the authentication helper through a dedicated services entry point and document usage in the README
- declare the mysql2 dependency so the helper can connect to a database in Node environments

## Testing
- not run (mysql2 package installation is blocked by the environment's npm registry restrictions)


------
https://chatgpt.com/codex/tasks/task_e_68d7e5e1ff808325abbc1202309f4a69