### PR TITLE
Inject bundle into page context

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -1,0 +1,16 @@
+(() => {
+  const SCRIPT_ID = "magicbuyer-page-script";
+  if (document.getElementById(SCRIPT_ID)) {
+    return;
+  }
+
+  const script = document.createElement("script");
+  script.id = SCRIPT_ID;
+  script.src = chrome.runtime.getURL("dist/magicbuyer.js");
+  script.type = "text/javascript";
+  script.onload = () => {
+    script.remove();
+  };
+
+  (document.head || document.documentElement).appendChild(script);
+})();

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
   "content_scripts": [
     {
       "matches": ["https://www.ea.com/*/ea-sports-fc/ultimate-team/web-app/*"],
-      "js": ["dist/magicbuyer.js"],
+      "js": ["contentScript.js"],
       "run_at": "document_idle"
     }
   ],
@@ -27,5 +27,11 @@
     "https://discordapp.com/*",
     "https://futbin.org/*",
     "https://exp.host/*"
+  ],
+  "web_accessible_resources": [
+    {
+      "resources": ["dist/magicbuyer.js"],
+      "matches": ["https://www.ea.com/*/ea-sports-fc/ultimate-team/web-app/*"]
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- add a lightweight content script that injects the compiled bundle into the page context
- expose the bundle via web accessible resources and update the manifest to use the injector

## Testing
- npm run build:prod *(fails: Module not found: Can't resolve './phoneDBUtil')*

------
https://chatgpt.com/codex/tasks/task_e_68d833a54bb483259564c2027f4a099a