### PR TITLE
Ensure dist output includes extension assets

### DIFF
--- a/app/utils/dbUtil.js
+++ b/app/utils/dbUtil.js
@@ -1,4 +1,4 @@
-import phoneDBUtil from "./phoneDBUtil";
+import phoneDBUtil from "./phoneDbUtil";
 
 export const initDatabase = () => phoneDBUtil.initDatabase();
 

--- a/app/vendor/jquery.js
+++ b/app/vendor/jquery.js
@@ -1,7 +1,20 @@
-import jquery from "jquery";
-
 const globalScope = typeof window !== "undefined" ? window : globalThis;
+
+const jquery = (() => {
+  if (globalScope.jQuery) {
+    return globalScope.jQuery;
+  }
+
+  if (globalScope.$) {
+    return globalScope.$;
+  }
+
+  throw new Error(
+    "MagicBuyer: jQuery is not available in the current context."
+  );
+})();
 
 globalScope.$ = jquery;
 globalScope.jQuery = jquery;
+
 export default jquery;

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "build:dev": "webpack --mode development",
-    "build:prod": "webpack --mode production",
+    "build:dev": "webpack --mode development && node scripts/copy-assets.js",
+    "build:prod": "webpack --mode production && node scripts/copy-assets.js",
     "serve": "webpack serve --mode development",
     "build:mobile": "npx babel dist/magicbuyer.js --out-file dist/magicbuyer.mobile.js --presets babel-preset-es2015"
   },

--- a/scripts/copy-assets.js
+++ b/scripts/copy-assets.js
@@ -1,0 +1,51 @@
+const fs = require('fs');
+const path = require('path');
+
+const rootDir = path.resolve(__dirname, '..');
+const distDir = path.join(rootDir, 'dist');
+
+const assets = [
+  'manifest.json',
+  'background.js',
+  'contentScript.js',
+  'external',
+  'storeImg',
+];
+
+const copyRecursiveSync = (src, dest) => {
+  const stats = fs.statSync(src);
+
+  if (stats.isDirectory()) {
+    fs.mkdirSync(dest, { recursive: true });
+    const entries = fs.readdirSync(src);
+    entries.forEach((entry) => {
+      const from = path.join(src, entry);
+      const to = path.join(dest, entry);
+      copyRecursiveSync(from, to);
+    });
+    return;
+  }
+
+  fs.mkdirSync(path.dirname(dest), { recursive: true });
+  fs.copyFileSync(src, dest);
+};
+
+const main = () => {
+  if (!fs.existsSync(distDir)) {
+    fs.mkdirSync(distDir, { recursive: true });
+  }
+
+  assets.forEach((asset) => {
+    const fromPath = path.join(rootDir, asset);
+    const toPath = path.join(distDir, asset);
+
+    if (!fs.existsSync(fromPath)) {
+      return;
+    }
+
+    fs.rmSync(toPath, { recursive: true, force: true });
+    copyRecursiveSync(fromPath, toPath);
+  });
+};
+
+main();


### PR DESCRIPTION
## Summary
- add a post-build copy script so the dist folder includes the manifest, scripts, and resource directories
- update npm build scripts to invoke the asset copy step after bundling
- rely on the host-provided jQuery global and fix a case-sensitive import for the IndexedDB helper

## Testing
- npm run build:prod

------
https://chatgpt.com/codex/tasks/task_e_68d838a763b48325b9c260e2f8797d8b