### PR TITLE
Update EA match patterns in manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,8 @@
   },
   "content_scripts": [
     {
-      "matches": ["https://www.ea.com/*/ea-sports-fc/ultimate-team/web-app/*"],
+      "matches": ["https://www.ea.com/*"],
+      "include_globs": ["*ea-sports-fc/ultimate-team/web-app/*"],
       "js": ["contentScript.js"],
       "run_at": "document_idle"
     }
@@ -37,7 +38,7 @@
         "dist/magicbuyer.js",
         "external/discord.11.4.2.min.js"
       ],
-      "matches": ["https://www.ea.com/*/ea-sports-fc/ultimate-team/web-app/*"]
+      "matches": ["https://www.ea.com/*"]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- replace deprecated EA Ultimate Team match patterns with a Chrome-supported pattern
- scope the content script with include_globs while keeping resources accessible on the ea.com domain

## Testing
- npm run build:prod

------
https://chatgpt.com/codex/tasks/task_e_68d83c57cc6483258bd3274b936e1256