### PR TITLE
Add extension popup for MagicBuyer controls

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -3,6 +3,7 @@ import { isMarketAlertApp } from "./app.constants";
 import { initOverrides } from "./function-overrides";
 import { cssOverride } from "./function-overrides/css-override";
 import { initListeners } from "./services/listeners";
+import { initPageCommandBridge } from "./services/pageCommandBridge";
 
 const initAutobuyer = function () {
   let isHomePageLoaded = false;
@@ -32,6 +33,7 @@ const initFunctionOverrides = function () {
     initOverrides();
     initAutobuyer();
     isMarketAlertApp && initListeners();
+    initPageCommandBridge();
   } else {
     setTimeout(initFunctionOverrides, 1000);
   }

--- a/app/popup/index.js
+++ b/app/popup/index.js
@@ -1,0 +1,126 @@
+const PAGE_COMMAND_REQUEST = "MAGIC_BUYER_PAGE_COMMAND";
+
+const queryActiveTab = () => {
+  return new Promise((resolve, reject) => {
+    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+      if (chrome.runtime.lastError) {
+        reject(chrome.runtime.lastError);
+        return;
+      }
+      if (!tabs || !tabs.length) {
+        reject(new Error("No active tab"));
+        return;
+      }
+      resolve(tabs[0]);
+    });
+  });
+};
+
+const sendCommand = async (command, args = {}) => {
+  const tab = await queryActiveTab();
+  return new Promise((resolve, reject) => {
+    chrome.tabs.sendMessage(
+      tab.id,
+      {
+        type: PAGE_COMMAND_REQUEST,
+        payload: { command, args },
+        id: `${Date.now()}-${Math.random()}`,
+      },
+      (response) => {
+        if (chrome.runtime.lastError) {
+          reject(chrome.runtime.lastError);
+          return;
+        }
+        if (!response) {
+          reject(new Error("No response from content script"));
+          return;
+        }
+        if (!response.success) {
+          reject(new Error(response.error || "Command failed"));
+          return;
+        }
+        resolve(response.payload);
+      }
+    );
+  });
+};
+
+const statusContainer = document.getElementById("status");
+const logsContainer = document.getElementById("logs");
+const errorContainer = document.getElementById("error");
+
+const setError = (message) => {
+  if (!message) {
+    errorContainer.textContent = "";
+    errorContainer.hidden = true;
+    return;
+  }
+  errorContainer.textContent = message;
+  errorContainer.hidden = false;
+};
+
+const updateStatus = async () => {
+  try {
+    const status = await sendCommand("getStatus");
+    const items = [
+      ["State", status.statusText || "Unknown"],
+      ["Requests", status.requestCount || "0"],
+      ["Coins", status.coins || "0"],
+      ["Profit", status.profit || "0"],
+      ["Won", status.won || "0"],
+      ["Sold", status.sold || "0"],
+      ["Unsold", status.unsold || "0"],
+      ["Available", status.available || "0"],
+      ["Active transfers", status.activeTransfers || "0"],
+      ["Countdown", status.countdown || "00:00:00"],
+    ];
+    statusContainer.innerHTML = items
+      .map(([label, value]) => `<div><strong>${label}:</strong> ${value}</div>`)
+      .join("");
+    setError("");
+  } catch (error) {
+    statusContainer.innerHTML = "";
+    setError(error?.message || "Unable to fetch status");
+  }
+};
+
+const updateLogs = async () => {
+  try {
+    const { html } = await sendCommand("getLogs");
+    logsContainer.innerHTML = `<ul>${html || ""}</ul>`;
+  } catch (error) {
+    logsContainer.innerHTML = "<em>Unable to load logs.</em>";
+    setError(error?.message || "Unable to load logs");
+  }
+};
+
+const withAction = (fn) => async () => {
+  try {
+    await fn();
+    setError("");
+    await updateStatus();
+    await updateLogs();
+  } catch (error) {
+    setError(error?.message || "Action failed");
+  }
+};
+
+const bindButton = (id, handler) => {
+  const el = document.getElementById(id);
+  if (!el) return;
+  el.addEventListener("click", withAction(handler));
+};
+
+bindButton("open", () => sendCommand("open"));
+bindButton("start", () => sendCommand("start"));
+bindButton("resume", () => sendCommand("resume"));
+bindButton("pause", () => sendCommand("pause"));
+bindButton("stop", () => sendCommand("stop"));
+bindButton("clear", () => sendCommand("clearLogs"));
+
+updateStatus();
+updateLogs();
+setInterval(() => {
+  updateStatus();
+  updateLogs();
+}, 5000);

--- a/app/services/pageCommandBridge.js
+++ b/app/services/pageCommandBridge.js
@@ -1,0 +1,163 @@
+import {
+  startAutoBuyer,
+  stopAutoBuyer,
+} from "../handlers/autobuyerProcessor";
+import { getValue } from "./repository";
+import { clearLogs } from "../utils/logUtil";
+import {
+  idAbStatus,
+  idAbRequestCount,
+  idAbCoins,
+  idAbProfit,
+  idWinCount,
+  idAbSoldItems,
+  idAbUnsoldItems,
+  idAbAvailableItems,
+  idAbActiveTransfers,
+  idAbSearchProgress,
+  idAbStatisticsProgress,
+  idAbCountDown,
+  idProgressAutobuyer,
+} from "../elementIds.constants";
+
+const PAGE_COMMAND_REQUEST = "MAGIC_BUYER_PAGE_COMMAND";
+const PAGE_COMMAND_RESPONSE = "MAGIC_BUYER_PAGE_COMMAND_RESPONSE";
+
+const commandHandlers = {
+  start: async () => {
+    const instance = getAutoBuyerInstance();
+    await startAutoBuyer.call(instance);
+    return { state: "started" };
+  },
+  resume: async () => {
+    const instance = getAutoBuyerInstance();
+    await startAutoBuyer.call(instance, true);
+    return { state: "resumed" };
+  },
+  stop: async () => {
+    const instance = getAutoBuyerInstance();
+    stopAutoBuyer.call(instance, false);
+    return { state: "stopped" };
+  },
+  pause: async () => {
+    const instance = getAutoBuyerInstance();
+    stopAutoBuyer.call(instance, true);
+    return { state: "paused" };
+  },
+  clearLogs: async () => {
+    clearLogs();
+    return { cleared: true };
+  },
+  getStatus: async () => {
+    return collectStatusSnapshot();
+  },
+  getLogs: async () => {
+    const logEl = document.getElementById(idProgressAutobuyer);
+    return {
+      html: logEl ? logEl.innerHTML : "",
+    };
+  },
+  open: async () => {
+    ensureAutoBuyerTab();
+    return { opened: true };
+  },
+};
+
+const getAutoBuyerInstance = () => {
+  const instance = getValue("AutoBuyerInstance");
+  if (!instance) {
+    throw new Error(
+      "MagicBuyer view is not initialized yet. Open the Ultimate Team web app and visit the MagicBuyer tab first."
+    );
+  }
+  return instance;
+};
+
+const ensureAutoBuyerTab = () => {
+  const tabItems = Array.from(
+    document.querySelectorAll(".ut-tab-bar-item")
+  ).filter((el) => el.textContent?.trim() === "MagicBuyer");
+  if (tabItems.length) {
+    const tab = tabItems[0];
+    tab.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    tab.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+    tab.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+  }
+};
+
+const collectStatusSnapshot = () => {
+  const textContent = (id) =>
+    document.getElementById(id)?.textContent?.trim() || "";
+
+  return {
+    statusText: textContent(idAbStatus),
+    requestCount: textContent(idAbRequestCount),
+    coins: textContent(idAbCoins),
+    profit: textContent(idAbProfit),
+    won: textContent(idWinCount),
+    sold: textContent(idAbSoldItems),
+    unsold: textContent(idAbUnsoldItems),
+    available: textContent(idAbAvailableItems),
+    activeTransfers: textContent(idAbActiveTransfers),
+    searchProgress: getProgressWidth(idAbSearchProgress),
+    statisticsProgress: getProgressWidth(idAbStatisticsProgress),
+    countdown: textContent(idAbCountDown),
+  };
+};
+
+const getProgressWidth = (id) => {
+  const el = document.getElementById(id);
+  if (!el) {
+    return 0;
+  }
+  const match = /([0-9.]+)%/.exec(el.style.width || "");
+  return match ? Number(match[1]) : 0;
+};
+
+const handlePageCommand = async (payload) => {
+  if (!payload || !payload.command) {
+    throw new Error("Invalid command");
+  }
+  const handler = commandHandlers[payload.command];
+  if (!handler) {
+    throw new Error(`Unknown command: ${payload.command}`);
+  }
+  return await handler(payload.args || {});
+};
+
+export const initPageCommandBridge = () => {
+  window.addEventListener("message", (event) => {
+    if (event.source !== window || !event.data) {
+      return;
+    }
+    const { type, id, payload } = event.data;
+    if (type !== PAGE_COMMAND_REQUEST || !id) {
+      return;
+    }
+
+    Promise.resolve()
+      .then(() => handlePageCommand(payload))
+      .then((result) => {
+        window.postMessage(
+          {
+            type: PAGE_COMMAND_RESPONSE,
+            id,
+            success: true,
+            payload: result,
+          },
+          "*"
+        );
+      })
+      .catch((error) => {
+        window.postMessage(
+          {
+            type: PAGE_COMMAND_RESPONSE,
+            id,
+            success: false,
+            error: error?.message || "Unknown command error",
+          },
+          "*"
+        );
+      });
+  });
+};

--- a/manifest.json
+++ b/manifest.json
@@ -3,6 +3,9 @@
   "name": "MagicBuyer-UT",
   "version": "2.0.0",
   "description": "UT Auto Buyer - French version",
+  "action": {
+    "default_popup": "popup.html"
+  },
   "background": {
     "service_worker": "background.js"
   },

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>MagicBuyer Control</title>
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        margin: 0;
+        padding: 16px;
+        min-width: 320px;
+        background: #0c1a2b;
+        color: #f2f2f2;
+      }
+      h1 {
+        font-size: 18px;
+        margin: 0 0 12px;
+        text-align: center;
+      }
+      .actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        justify-content: center;
+        margin-bottom: 12px;
+      }
+      button {
+        background: #1f8eed;
+        border: none;
+        border-radius: 4px;
+        color: #fff;
+        cursor: pointer;
+        padding: 6px 12px;
+        font-size: 14px;
+      }
+      button.secondary {
+        background: #2d3436;
+      }
+      button.danger {
+        background: #e74c3c;
+      }
+      button:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+      }
+      .status {
+        font-size: 13px;
+        line-height: 1.4;
+        margin-bottom: 12px;
+        background: rgba(255, 255, 255, 0.06);
+        padding: 8px;
+        border-radius: 4px;
+      }
+      .status strong {
+        display: inline-block;
+        min-width: 120px;
+      }
+      .logs {
+        max-height: 240px;
+        overflow-y: auto;
+        background: rgba(0, 0, 0, 0.4);
+        border-radius: 4px;
+        padding: 8px;
+      }
+      .logs ul {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+      }
+      .error {
+        color: #ff7675;
+        margin-bottom: 8px;
+      }
+      .hint {
+        font-size: 12px;
+        color: #b2bec3;
+        margin-top: 8px;
+        text-align: center;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>MagicBuyer Control</h1>
+    <div id="error" class="error" hidden></div>
+    <div class="actions">
+      <button id="open">Open MagicBuyer Tab</button>
+      <button id="start">Start</button>
+      <button id="resume">Resume</button>
+      <button id="pause" class="secondary">Pause</button>
+      <button id="stop" class="danger">Stop</button>
+      <button id="clear" class="secondary">Clear Log</button>
+    </div>
+    <div id="status" class="status"></div>
+    <div class="logs" id="logs"></div>
+    <div class="hint">
+      Use the Ultimate Team web app in the active tab. The MagicBuyer tab must be initialized once per session.
+    </div>
+    <script src="dist/popup.js"></script>
+  </body>
+</html>

--- a/scripts/copy-assets.js
+++ b/scripts/copy-assets.js
@@ -8,6 +8,7 @@ const assets = [
   'manifest.json',
   'background.js',
   'contentScript.js',
+  'popup.html',
   'external',
   'storeImg',
 ];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,10 +2,13 @@ const path = require("path");
 const TerserPlugin = require("terser-webpack-plugin");
 
 module.exports = {
-  entry: "./app/index.js",
+  entry: {
+    magicbuyer: "./app/index.js",
+    popup: "./app/popup/index.js",
+  },
   output: {
     path: path.resolve(__dirname, "dist"),
-    filename: "magicbuyer.js",
+    filename: "[name].js",
   },
   devServer: {
     contentBase: path.resolve(__dirname, "dist"),


### PR DESCRIPTION
## Summary
- add a popup UI to the extension that surfaces MagicBuyer controls and log output
- bridge popup commands into the page so AutoBuyerViewController actions can be triggered remotely
- update the build pipeline and asset copy script to bundle the new popup resources

## Testing
- npm run build:prod

------
https://chatgpt.com/codex/tasks/task_e_68d83f1212dc8325bbcdfef0de050630