### PR TITLE
Fix popup script path during asset copy

### DIFF
--- a/dist/popup.html
+++ b/dist/popup.html
@@ -169,6 +169,6 @@
     <div class="hint">
       Use the Ultimate Team web app in the active tab. The MagicBuyer tab must be initialized once per session.
     </div>
-    <script src="dist/popup.js"></script>
+    <script src="popup.js"></script>
   </body>
 </html>

--- a/scripts/copy-assets.js
+++ b/scripts/copy-assets.js
@@ -45,6 +45,18 @@ const main = () => {
     }
 
     fs.rmSync(toPath, { recursive: true, force: true });
+
+    if (asset === 'popup.html') {
+      const originalContent = fs.readFileSync(fromPath, 'utf8');
+      const updatedContent = originalContent.replace(
+        'src="dist/popup.js"',
+        'src="popup.js"'
+      );
+      fs.mkdirSync(path.dirname(toPath), { recursive: true });
+      fs.writeFileSync(toPath, updatedContent);
+      return;
+    }
+
     copyRecursiveSync(fromPath, toPath);
   });
 };


### PR DESCRIPTION
## Summary
- update the asset copy script to rewrite the popup HTML so the script tag points to the built bundle in dist
- regenerate dist/popup.html with the corrected script path

## Testing
- npm run build:prod

------
https://chatgpt.com/codex/tasks/task_e_68d84bb98cf483258560fabc90390f08