### PR TITLE
Signal page bundle readiness for settings bridge

### DIFF
--- a/app/page/index.js
+++ b/app/page/index.js
@@ -191,3 +191,13 @@ window.addEventListener("message", (event) => {
       .catch((e) => console.error("[MagicBuyer] openSettings error:", e));
   }
 });
+
+// Notifica al content script que el bundle de página está listo para recibir comandos
+if (!window.__mbPageReadyNotified) {
+  window.__mbPageReadyNotified = true;
+  try {
+    window.postMessage({ type: "MAGIC_BUYER_PAGE_READY" }, "*");
+  } catch (e) {
+    console.error("[MagicBuyer] Failed to dispatch PAGE_READY event:", e);
+  }
+}


### PR DESCRIPTION
## Summary
- emit a MAGIG_BUYER_PAGE_READY event from the page bundle once it is loaded
- guard against duplicate notifications and log any failure to dispatch the ready event

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8894c8f688325af25cf4d473a25b9