### PR TITLE
Require MySQL-backed login before initializing MagicBuyer

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,30 @@ Now in Ultimate Team Web App, new menu will be added as AutoBuyer.
 
 - If enabled tool will gives sound notification for actions like buy card / captcha trigger etc...
 
+## Inicio de sesión obligatorio
+
+Antes de que el autobuyer se active, MagicBuyer mostrará ahora un formulario de inicio de sesión. Solo después de validar las credenciales frente a tu base de datos MySQL se cargarán las vistas y listeners del bot. Si la sesión caduca, el cuadro de diálogo volverá a mostrarse.
+
+Para que el formulario pueda conectar con tu base de datos necesitas exponer una configuración en tiempo de ejecución mediante la variable global `window.MAGICBUYER_AUTH_CONFIG` (también puedes almacenarla en Tampermonkey con `GM_setValue`). Un ejemplo básico sería:
+
+```js
+window.MAGICBUYER_AUTH_CONFIG = {
+  connection: {
+    host: "db-host",
+    user: "db-user",
+    password: "secret",
+    database: "magicbuyer",
+  },
+  options: {
+    tableName: "users",
+    usernameField: "email",
+    selectFields: ["id", "email", "role"],
+  },
+};
+```
+
+La vista recuerda la sesión durante seis horas por defecto y durante 24 horas si marcas la casilla **Recordarme**. Puedes forzar el cierre de sesión desde la consola del navegador ejecutando `window.MagicBuyerAuth?.clearSession()`.
+
 ## MySQL Login Verification Service
 
 The project now ships with a small authentication helper located at

--- a/app/index.js
+++ b/app/index.js
@@ -2,6 +2,7 @@ import { isMarketAlertApp } from "./app.constants";
 import { initOverrides } from "./function-overrides";
 import { cssOverride } from "./function-overrides/css-override";
 import { initListeners } from "./services/listeners";
+import { ensureAuthenticated } from "./services/auth/loginManager";
 
 const initAutobuyer = function () {
   let isHomePageLoaded = false;
@@ -22,15 +23,30 @@ const initAutobuyer = function () {
   }
 };
 
+let initializationStarted = false;
+
 const initFunctionOverrides = function () {
   let isPageLoaded = false;
   if (services.Localization) {
     isPageLoaded = true;
   }
   if (isPageLoaded) {
-    initOverrides();
-    initAutobuyer();
-    isMarketAlertApp && initListeners();
+    if (initializationStarted) {
+      return;
+    }
+    initializationStarted = true;
+
+    ensureAuthenticated()
+      .then(() => {
+        initOverrides();
+        initAutobuyer();
+        isMarketAlertApp && initListeners();
+      })
+      .catch((error) => {
+        console.error("MagicBuyer authentication failed", error);
+        initializationStarted = false;
+        setTimeout(initFunctionOverrides, 3000);
+      });
   } else {
     setTimeout(initFunctionOverrides, 1000);
   }

--- a/app/services/auth/configResolver.js
+++ b/app/services/auth/configResolver.js
@@ -1,0 +1,53 @@
+const CONFIG_GLOBAL_KEY = "MAGICBUYER_AUTH_CONFIG";
+
+const tryParseJSON = (value) => {
+  if (typeof value === "string") {
+    try {
+      return JSON.parse(value);
+    } catch (error) {
+      return null;
+    }
+  }
+  return value && typeof value === "object" ? value : null;
+};
+
+const getRuntimeConfig = () => {
+  const globalScope =
+    (typeof unsafeWindow !== "undefined" && unsafeWindow) ||
+    (typeof window !== "undefined" && window) ||
+    (typeof globalThis !== "undefined" && globalThis);
+
+  if (globalScope && globalScope[CONFIG_GLOBAL_KEY]) {
+    return tryParseJSON(globalScope[CONFIG_GLOBAL_KEY]);
+  }
+
+  if (typeof GM_getValue === "function") {
+    const storedConfig = GM_getValue(CONFIG_GLOBAL_KEY);
+    if (storedConfig) {
+      return tryParseJSON(storedConfig);
+    }
+  }
+
+  return null;
+};
+
+export const resolveAuthConfig = () => {
+  const runtimeConfig = getRuntimeConfig();
+  if (!runtimeConfig || typeof runtimeConfig !== "object") {
+    throw new Error(
+      "No se encontró la configuración de autenticación. Define `window.MAGICBUYER_AUTH_CONFIG` con los datos de conexión MySQL."
+    );
+  }
+
+  const { connection, options = {} } = runtimeConfig;
+
+  if (!connection || typeof connection !== "object") {
+    throw new Error(
+      "La configuración de autenticación debe incluir un objeto `connection` válido."
+    );
+  }
+
+  return { connection, options };
+};
+
+export const getConfigGlobalKey = () => CONFIG_GLOBAL_KEY;

--- a/app/services/auth/index.js
+++ b/app/services/auth/index.js
@@ -1,4 +1,12 @@
 import { createMySQLAuthService } from "./mysqlAuthService";
+import { ensureAuthenticated, clearStoredSession } from "./loginManager";
+import { resolveAuthConfig, getConfigGlobalKey } from "./configResolver";
 
-export { createMySQLAuthService };
+export {
+  createMySQLAuthService,
+  ensureAuthenticated,
+  clearStoredSession,
+  resolveAuthConfig,
+  getConfigGlobalKey,
+};
 

--- a/app/services/auth/loginManager.js
+++ b/app/services/auth/loginManager.js
@@ -1,0 +1,117 @@
+import { setValue, getValue } from "../repository";
+import { createMySQLAuthService } from "./mysqlAuthService";
+import { resolveAuthConfig } from "./configResolver";
+import { renderLoginOverlay } from "../../views/layouts/LoginView";
+
+const AUTH_SESSION_KEY = "MagicBuyerAuthSession";
+const DEFAULT_SESSION_TTL = 6 * 60 * 60 * 1000; // 6 horas
+const REMEMBER_ME_SESSION_TTL = 24 * 60 * 60 * 1000; // 24 horas
+
+let authServiceInstance;
+let loginPromise;
+
+const getAuthService = () => {
+  if (!authServiceInstance) {
+    const { connection, options } = resolveAuthConfig();
+    authServiceInstance = createMySQLAuthService(connection, options);
+  }
+  return authServiceInstance;
+};
+
+const persistSession = (session, remember) => {
+  const ttl = remember ? REMEMBER_ME_SESSION_TTL : DEFAULT_SESSION_TTL;
+  setValue(AUTH_SESSION_KEY, {
+    ...session,
+    expiryTimeStamp: Date.now() + ttl,
+  });
+};
+
+const describeFailure = (result) => {
+  switch (result.reason) {
+    case "USER_NOT_FOUND":
+      return "El usuario no existe.";
+    case "INVALID_PASSWORD":
+      return "La contraseña no es válida.";
+    case "ERROR":
+    default:
+      return result.error
+        ? `Error al validar las credenciales: ${result.error}`
+        : "No se pudo validar las credenciales.";
+  }
+};
+
+export const clearStoredSession = () => {
+  setValue(AUTH_SESSION_KEY, {
+    expiryTimeStamp: Date.now() - 1000,
+  });
+};
+
+export const ensureAuthenticated = () => {
+  const storedSession = getValue(AUTH_SESSION_KEY);
+  if (storedSession && storedSession.success) {
+    return Promise.resolve(storedSession);
+  }
+
+  if (!loginPromise) {
+    loginPromise = new Promise((resolve, reject) => {
+      let loginView;
+      try {
+        loginView = renderLoginOverlay({
+          onSubmit: async (credentials, helpers) => {
+            const { username, password, remember } = credentials;
+            const { setLoading, setError, clearPassword, focusUsername } = helpers;
+
+            if (!username || !password) {
+              setError("Introduce usuario y contraseña.");
+              return;
+            }
+
+            setError("");
+            setLoading(true);
+
+            try {
+              const authService = getAuthService();
+              const result = await authService.login(username, password);
+
+              if (result.success) {
+                persistSession(result, remember);
+                loginView.remove();
+                resolve(result);
+              } else {
+                setError(describeFailure(result));
+                setLoading(false);
+                clearPassword();
+                focusUsername();
+              }
+            } catch (error) {
+              console.error("MagicBuyer login error", error);
+              setError(
+                error instanceof Error
+                  ? error.message
+                  : "Se produjo un error inesperado al iniciar sesión."
+              );
+              setLoading(false);
+              clearPassword();
+              focusUsername();
+            }
+          },
+        });
+      } catch (error) {
+        console.error("MagicBuyer login view error", error);
+        reject(error);
+        return;
+      }
+
+      loginView.focus();
+    }).finally(() => {
+      loginPromise = null;
+    });
+  }
+
+  return loginPromise;
+};
+
+if (typeof window !== "undefined") {
+  window.MagicBuyerAuth = window.MagicBuyerAuth || {};
+  window.MagicBuyerAuth.clearSession = clearStoredSession;
+}

--- a/app/views/layouts/LoginView.js
+++ b/app/views/layouts/LoginView.js
@@ -1,0 +1,227 @@
+const STYLE_ID = "magicbuyer-login-style";
+const OVERLAY_ID = "magicbuyer-login-overlay";
+
+const ensureStyles = () => {
+  if (document.getElementById(STYLE_ID)) {
+    return;
+  }
+
+  const style = document.createElement("style");
+  style.id = STYLE_ID;
+  style.textContent = `
+    #${OVERLAY_ID} {
+      align-items: center;
+      backdrop-filter: blur(4px);
+      background: rgba(6, 17, 34, 0.85);
+      bottom: 0;
+      color: #fff;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      left: 0;
+      padding: 24px;
+      position: fixed;
+      right: 0;
+      top: 0;
+      z-index: 9999;
+      font-family: FUTFont, Arial, sans-serif;
+    }
+
+    #${OVERLAY_ID} .magicbuyer-login-card {
+      background: rgba(12, 26, 50, 0.95);
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      border-radius: 12px;
+      box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
+      max-width: 360px;
+      padding: 32px 28px;
+      width: 100%;
+    }
+
+    #${OVERLAY_ID} h2 {
+      font-size: 22px;
+      font-weight: 700;
+      letter-spacing: 0.06em;
+      margin: 0 0 16px;
+      text-align: center;
+      text-transform: uppercase;
+    }
+
+    #${OVERLAY_ID} form {
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+    }
+
+    #${OVERLAY_ID} label {
+      display: flex;
+      flex-direction: column;
+      font-size: 13px;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+
+    #${OVERLAY_ID} input[type="text"],
+    #${OVERLAY_ID} input[type="password"] {
+      background: rgba(255, 255, 255, 0.05);
+      border: 1px solid rgba(255, 255, 255, 0.15);
+      border-radius: 8px;
+      color: #fff;
+      font-size: 14px;
+      margin-top: 6px;
+      padding: 10px 12px;
+    }
+
+    #${OVERLAY_ID} input[type="text"]:focus,
+    #${OVERLAY_ID} input[type="password"]:focus {
+      border-color: #21c25e;
+      outline: none;
+      box-shadow: 0 0 0 1px #21c25e;
+    }
+
+    #${OVERLAY_ID} .remember-row {
+      align-items: center;
+      display: flex;
+      font-size: 12px;
+      gap: 8px;
+      justify-content: flex-start;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+
+    #${OVERLAY_ID} .error-message {
+      color: #ff6b6b;
+      font-size: 13px;
+      min-height: 18px;
+      text-align: center;
+    }
+
+    #${OVERLAY_ID} button[type="submit"] {
+      background: linear-gradient(135deg, #21c25e, #12843a);
+      border: none;
+      border-radius: 8px;
+      color: #031321;
+      cursor: pointer;
+      font-size: 15px;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      padding: 12px 16px;
+      text-transform: uppercase;
+      transition: transform 0.15s ease, box-shadow 0.15s ease;
+    }
+
+    #${OVERLAY_ID} button[type="submit"]:hover:not(:disabled) {
+      box-shadow: 0 8px 18px rgba(33, 194, 94, 0.45);
+      transform: translateY(-1px);
+    }
+
+    #${OVERLAY_ID} button[type="submit"]:disabled {
+      cursor: not-allowed;
+      opacity: 0.65;
+    }
+
+    #${OVERLAY_ID} .magicbuyer-login-footer {
+      font-size: 11px;
+      letter-spacing: 0.04em;
+      margin-top: 18px;
+      opacity: 0.75;
+      text-align: center;
+      text-transform: uppercase;
+    }
+  `;
+
+  const target =
+    document.head || document.getElementsByTagName("head")[0] || document.documentElement;
+  target.appendChild(style);
+};
+
+const createOverlay = () => {
+  ensureStyles();
+
+  if (!document.body) {
+    throw new Error("El documento todavía no está listo para mostrar el formulario de acceso.");
+  }
+
+  let overlay = document.getElementById(OVERLAY_ID);
+  if (overlay) {
+    overlay.remove();
+  }
+
+  overlay = document.createElement("div");
+  overlay.id = OVERLAY_ID;
+  overlay.innerHTML = `
+    <div class="magicbuyer-login-card">
+      <h2>MagicBuyer</h2>
+      <form>
+        <label>
+          Usuario
+          <input type="text" name="username" autocomplete="username" />
+        </label>
+        <label>
+          Contraseña
+          <input type="password" name="password" autocomplete="current-password" />
+        </label>
+        <div class="remember-row">
+          <input type="checkbox" id="magicbuyer-remember" name="remember" />
+          <label for="magicbuyer-remember">Recordarme</label>
+        </div>
+        <div class="error-message" role="alert"></div>
+        <button type="submit">Iniciar sesión</button>
+      </form>
+      <div class="magicbuyer-login-footer">
+        Debes autenticarte para usar el autobuyer
+      </div>
+    </div>
+  `;
+
+  document.body.appendChild(overlay);
+  return overlay;
+};
+
+export const renderLoginOverlay = ({ onSubmit }) => {
+  const overlay = createOverlay();
+  const form = overlay.querySelector("form");
+  const usernameInput = form.querySelector('input[name="username"]');
+  const passwordInput = form.querySelector('input[name="password"]');
+  const rememberInput = form.querySelector('input[name="remember"]');
+  const errorContainer = form.querySelector(".error-message");
+  const submitButton = form.querySelector('button[type="submit"]');
+
+  const setError = (message) => {
+    errorContainer.textContent = message || "";
+  };
+
+  const setLoading = (isLoading) => {
+    submitButton.disabled = Boolean(isLoading);
+    submitButton.textContent = isLoading ? "Verificando..." : "Iniciar sesión";
+  };
+
+  form.addEventListener("submit", (event) => {
+    event.preventDefault();
+    onSubmit(
+      {
+        username: usernameInput.value.trim(),
+        password: passwordInput.value,
+        remember: rememberInput.checked,
+      },
+      {
+        setError,
+        setLoading,
+        clearPassword: () => {
+          passwordInput.value = "";
+        },
+        focusUsername: () => {
+          usernameInput.focus();
+        },
+      }
+    );
+  });
+
+  return {
+    remove: () => {
+      overlay.remove();
+    },
+    focus: () => {
+      usernameInput.focus();
+    },
+  };
+};

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
   },
   "author": "AMINE1921",
   "license": "ISC",
+  "dependencies": {
+    "mysql2": "^3.9.6"
+  },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-preset-es2015": "^6.24.1",


### PR DESCRIPTION
## Summary
- gate the autobuyer initialisation behind a modal login that validates credentials against MySQL
- add runtime authentication helpers, expose a session clearer, and wire the flow into the existing bootstrap
- document the new setup requirements and declare the mysql2 runtime dependency

## Testing
- npm install --package-lock-only *(fails: 403 Forbidden when downloading mysql2)*

------
https://chatgpt.com/codex/tasks/task_e_68d92fdf974c8325b3da69934863d8b9