### PR TITLE
Fix filter saving when local cache missing

### DIFF
--- a/app/utils/userExternalUtil.js
+++ b/app/utils/userExternalUtil.js
@@ -73,8 +73,10 @@ export const saveFilterInDB = (filterName, settingsJson) => {
   checkAndAppendOption(filterDropdownId, filterName);
   checkAndAppendOption(`#${ElementIds.idSelectedFilter}`, filterName);
   $(`${filterDropdownId} option[value="${filterName}"]`).attr("selected", true);
-  getValue("filters")[filterName] = JSON.stringify(settingsJson);
-  insertFilters(filterName, getValue("filters")[filterName]);
+  const filters = getValue("filters") || {};
+  filters[filterName] = JSON.stringify(settingsJson);
+  setValue("filters", filters);
+  insertFilters(filterName, filters[filterName]);
 };
 
 const loadDefaultFilter = () => {


### PR DESCRIPTION
## Summary
- guard filter persistence against missing in-memory cache entries when saving
- ensure the refreshed cache is stored before writing the filter to IndexedDB

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd80e08888832597d3ef445d12d84a