### PR TITLE
Add export option for filters and handle player data

### DIFF
--- a/app/function-overrides/css-override.js
+++ b/app/function-overrides/css-override.js
@@ -138,6 +138,9 @@ export const cssOverride = () => {
   .btn-delete-filter {
     width:50%
   }
+  .btn-download-filter {
+    width:50%
+  }
   .multiple-filter {
     width: 100%  !important;
     display: flex  !important;

--- a/app/utils/dbUtil.js
+++ b/app/utils/dbUtil.js
@@ -1,12 +1,12 @@
-import phoneDBUtil from "./phoneDBUtil";
+import phoneDbUtil from "./phoneDbUtil";
 
-export const initDatabase = () => phoneDBUtil.initDatabase();
+export const initDatabase = () => phoneDbUtil.initDatabase();
 
 export const getUserFilters = (storeName = "Filters") =>
-  phoneDBUtil.getUserFilters(storeName);
+  phoneDbUtil.getUserFilters(storeName);
 
 export const insertFilters = (filterName, jsonData, storeName = "Filters") =>
-  phoneDBUtil.insertFilters(filterName, jsonData, storeName);
+  phoneDbUtil.insertFilters(filterName, jsonData, storeName);
 
 export const deleteFilters = (filterName) =>
-  phoneDBUtil.deleteFilters(filterName);
+  phoneDbUtil.deleteFilters(filterName);

--- a/app/utils/filterSyncUtil.js
+++ b/app/utils/filterSyncUtil.js
@@ -2,11 +2,12 @@ import {
   idAbFiltersToUpload,
   idAbFiltersFileToUpload,
 } from "../elementIds.constants";
-import { getValue } from "../services/repository";
+import { getValue, setValue } from "../services/repository";
 import { downloadJson } from "./commonUtil";
 import { showPopUp } from "./popupUtil";
 import { saveFilterInDB } from "./userExternalUtil";
 import { sendUINotification } from "./notificationUtil";
+import { insertFilters } from "./dbUtil";
 
 $(document).on(
   {
@@ -19,6 +20,11 @@ $(document).on(
 
 export const downloadFilters = () => {
   const userFilters = getValue("filters");
+
+  if (!userFilters || !Object.keys(userFilters).length) {
+    sendUINotification("No filters available to download", UINotificationType.NEGATIVE);
+    return;
+  }
 
   let filterMessage = `Choose filters to Download <br /> <br />
   <select  multiple="multiple" class="multiselect-filter filter-header-settings" id="${idAbFiltersToUpload}"
@@ -93,6 +99,15 @@ const uploadFilterConfirm = () => {
 
     for (let filter in parsedFilters.filters) {
       saveFilterInDB(filter, parsedFilters.filters[filter]);
+    }
+
+    if (parsedFilters.commonSettings) {
+      insertFilters(
+        "CommonSettings",
+        JSON.stringify(parsedFilters.commonSettings),
+        "CommonSettings"
+      );
+      setValue("CommonSettings", parsedFilters.commonSettings);
     }
     sendUINotification("Filters uploaded successfully");
   };

--- a/app/utils/userExternalUtil.js
+++ b/app/utils/userExternalUtil.js
@@ -5,10 +5,91 @@ import {
   clearSettingMenus,
   updateCommonSettings,
 } from "../views/layouts/MenuItemView";
-import { updateSettingsView } from "./commonUtil";
+import { updateSettingsView, downloadJson } from "./commonUtil";
 import { deleteFilters, insertFilters } from "./dbUtil";
 import { checkAndAppendOption, updateMultiFilterSettings } from "./filterUtil";
 import { sendUINotification } from "./notificationUtil";
+
+const sanitizeForStorage = (value, seen = new WeakMap()) => {
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+
+  if (seen.has(value)) {
+    return seen.get(value);
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (value instanceof Map) {
+    const mapResult = {};
+    seen.set(value, mapResult);
+    value.forEach((mapValue, key) => {
+      mapResult[key] = sanitizeForStorage(mapValue, seen);
+    });
+    return mapResult;
+  }
+
+  if (value instanceof Set) {
+    const setResult = [];
+    seen.set(value, setResult);
+    value.forEach((setValue) => {
+      setResult.push(sanitizeForStorage(setValue, seen));
+    });
+    return setResult;
+  }
+
+  if (Array.isArray(value)) {
+    const arr = [];
+    seen.set(value, arr);
+    value.forEach((item) => {
+      arr.push(sanitizeForStorage(item, seen));
+    });
+    return arr;
+  }
+
+  if (value.nodeType && typeof value.cloneNode === "function") {
+    return undefined;
+  }
+
+  const sanitizedObject = {};
+  seen.set(value, sanitizedObject);
+
+  Object.keys(value).forEach((key) => {
+    const currentValue = value[key];
+    if (typeof currentValue === "function") {
+      return;
+    }
+    const sanitizedValue = sanitizeForStorage(currentValue, seen);
+    if (sanitizedValue !== undefined) {
+      sanitizedObject[key] = sanitizedValue;
+    }
+  });
+
+  return sanitizedObject;
+};
+
+const createFilterSnapshot = (viewModel, buyerSetting) => {
+  const criteria = viewModel?.searchCriteria
+    ? sanitizeForStorage(viewModel.searchCriteria)
+    : {};
+  const playerData = viewModel?.playerData
+    ? sanitizeForStorage(viewModel.playerData)
+    : null;
+  const buyerSettings = buyerSetting
+    ? sanitizeForStorage(buyerSetting)
+    : {};
+
+  return {
+    searchCriteria: {
+      criteria,
+      playerData,
+      buyerSettings,
+    },
+  };
+};
 
 const validateSettings = () => {
   if (document.querySelectorAll(":invalid").length) {
@@ -28,13 +109,8 @@ export const saveFilterDetails = function (self) {
   let buyerSetting = getBuyerSettings(true);
   let commonSettings = getValue("CommonSettings");
   setTimeout(function () {
-    let settingsJson = {};
     const viewModel = self._viewmodel;
-    settingsJson.searchCriteria = {
-      criteria: viewModel.searchCriteria,
-      playerData: viewModel.playerData,
-      buyerSettings: buyerSetting,
-    };
+    const settingsJson = createFilterSnapshot(viewModel, buyerSetting);
 
     let currentFilterName = $(`${filterDropdownId} option`)
       .filter(":selected")
@@ -65,6 +141,55 @@ export const saveFilterDetails = function (self) {
       $(btnContext).removeClass("active");
       sendUINotification("Filter Name Required", UINotificationType.NEGATIVE);
     }
+  }, 200);
+};
+
+export const downloadCurrentFilter = function (self) {
+  const btnContext = this;
+  $(btnContext).addClass("active");
+  setTimeout(function () {
+    const buyerSetting = getBuyerSettings(true);
+    const viewModel = self._viewmodel;
+    const currentFilter = getValue("currentFilter") || "CURRENT_FILTER";
+    let filterName = prompt(
+      "Enter a name for the exported filter",
+      currentFilter
+    );
+
+    if (!filterName) {
+      $(btnContext).removeClass("active");
+      sendUINotification("Filter Name Required", UINotificationType.NEGATIVE);
+      return;
+    }
+
+    filterName = filterName.trim();
+
+    if (!filterName.length) {
+      $(btnContext).removeClass("active");
+      sendUINotification("Filter Name Required", UINotificationType.NEGATIVE);
+      return;
+    }
+
+    const sanitizedFilterName = filterName.toUpperCase();
+    const downloadFileName = `${filterName
+      .replace(/\s+/g, "_")
+      .toLowerCase()}_filter`;
+
+    const settingsJson = createFilterSnapshot(viewModel, buyerSetting);
+    const downloadPayload = {
+      filters: {
+        [sanitizedFilterName]: settingsJson,
+      },
+    };
+
+    const commonSettings = getValue("CommonSettings");
+    if (commonSettings) {
+      downloadPayload.commonSettings = sanitizeForStorage(commonSettings);
+    }
+
+    downloadJson(downloadPayload, downloadFileName);
+    $(btnContext).removeClass("active");
+    sendUINotification("Filter downloaded successfully");
   }, 200);
 };
 

--- a/app/views/layouts/Settings/FilterSettingsView.js
+++ b/app/views/layouts/Settings/FilterSettingsView.js
@@ -20,6 +20,7 @@ import {
   deleteFilter,
   loadFilter,
   saveFilterDetails,
+  downloadCurrentFilter,
 } from "../../../utils/userExternalUtil";
 import { createButton } from "../ButtonView";
 import { showPopUp } from "../../../utils/popupUtil";
@@ -247,6 +248,15 @@ const appendButtons = function (rootHeader, context) {
         saveFilterDetails.call(this, context);
       },
       "call-to-action btn-save-filter"
+    ).__root
+  );
+  buttons.append(
+    createButton(
+      "Download Current",
+      function () {
+        downloadCurrentFilter.call(this, context);
+      },
+      "call-to-action btn-download-filter"
     ).__root
   );
   btnReport.append(


### PR DESCRIPTION
## Summary
- sanitize search criteria and player data before saving filters so player-based filters persist correctly
- add a "Download Current" action to export the active search filter together with common settings
- include optional common settings when importing filter files and fix case-sensitive database util import

## Testing
- npm run build:dev

------
https://chatgpt.com/codex/tasks/task_e_68dd82dd8f608325aacfd1d15f278406